### PR TITLE
Add uninstall notes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ new System.Collections.Generic.Dictionary<string, string>() {
 ## Installation of release version
 Use instructions from marketplace.
 
+## Uninstalling
+When CSharpFixFormat is installed, it recommends to disable C# code format.
+After removing the extension, you should manually restore the code format setting:
+1. Open VS Code settings
+2. Set `"csharp.format.enable": true`
+3. Reload the application
 
 ## Installation from sources
 1. Install node.js.


### PR DESCRIPTION
When a users uninstall the extension, the default C# code formatter is probably disabled (following the recommendation displayed during the initial setup). 

This note will remind users to restore the original settings, so that OmniSharp will work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leopotam/vscode-csharpfixformat/75)
<!-- Reviewable:end -->
